### PR TITLE
Move badge below title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![Stories in Ready](https://badge.waffle.io/infolab-csail/wikithingsdb.png?label=ready&title=Ready)](https://waffle.io/infolab-csail/wikithingsdb)
 # WikiThingsDB
+[![Stories in Ready](https://badge.waffle.io/infolab-csail/wikithingsdb.png?label=ready&title=Ready)](https://waffle.io/infolab-csail/wikithingsdb)
+
 A DB of Synonyms, Paraphrases, and Hypernyms for all Wiki Things (Articles)
 
 ## Install


### PR DESCRIPTION
I didn't realize that waffle would just slap the badge at the top of the README, so I've fixed it here (sorry I merged #18 to achieve this).