### PR TITLE
Add random flag to articles_of_class

### DIFF
--- a/wikithingsdb/query.py
+++ b/wikithingsdb/query.py
@@ -146,17 +146,27 @@ def articles_with_multiple_types(*types, **kwargs):
     return [x.title for x in result]
 
 
-def articles_of_class(w_class, limit=sys.maxint):
+def articles_of_class(w_class, limit=sys.maxint, random=False):
     """
     Given a wikipedia class, return all articles of that type.
+    Set random=True to get random articles from the database (slower)
     """
     w_class = to_wikipedia_class(w_class)
-    result = (Article
-              .select()
-              .join(ArticleClass)
-              .join(WikiClass)
-              .where(WikiClass.class_name == w_class)
-              .limit(limit))
+    if random:
+        result = (Article
+                  .select()
+                  .join(ArticleClass)
+                  .join(WikiClass)
+                  .where(WikiClass.class_name == w_class)
+                  .order_by(fn.Random())
+                  .limit(limit))
+    else:
+        result = (Article
+                  .select()
+                  .join(ArticleClass)
+                  .join(WikiClass)
+                  .where(WikiClass.class_name == w_class)
+                  .limit(limit))
     return [x.title for x in result]
 
 


### PR DESCRIPTION
Added keyword argument to `articles_of_class` to get random articles from the database. It uses peewee's random function in an ORDER BY clause.

The DB query is slower when random is set to True, so I set the default value to False.

It's possible that we might want to do the same for other methods such as `articles_of_type`. However, I think it's best if we experiment with `articles_of_class` first and then decide how to proceed.