### PR TITLE
Remove Codecov, Waffle, and Quantified Code

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-omit = *virtualenv*, *pypy*, *setup.py, */tests/*, */scripts/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,12 @@ python:
 services:
 - postgresql
 before_install:
-- pip install codecov pep8
+- pip install pep8
 install:
 - pip install -r requirements.txt
 - python setup.py install
 - scripts/configure_db.py
 script:
 - python scripts/insert_fake_data_and_test.py
-- coverage run setup.py test
+- python setup.py test
 - pep8 wikithingsdb tests scripts --ignore=E501
-after_success:
-- codecov

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # WikiThingsDB
 [![Build Status](https://travis-ci.org/infolab-csail/wikithingsdb.svg?branch=master)](https://travis-ci.org/infolab-csail/wikithingsdb)
-[![Code Issues](https://www.quantifiedcode.com/api/v1/project/7a3c7f1330e74b1fad21206f454a212c/badge.svg)](https://www.quantifiedcode.com/app/project/7a3c7f1330e74b1fad21206f454a212c)
-[![Stories in Ready](https://badge.waffle.io/infolab-csail/wikithingsdb.png?label=ready&title=Ready)](https://waffle.io/infolab-csail/wikithingsdb)
-[![codecov.io](https://codecov.io/github/infolab-csail/wikithingsdb/coverage.svg?branch=master)](https://codecov.io/github/infolab-csail/wikithingsdb?branch=master)
 
 A DB of Synonyms, Paraphrases, and Hypernyms for all Wiki Things (Articles)
 


### PR DESCRIPTION
- For Codecov, see Issue https://github.com/infolab-csail/infolab-core/issues/243
- For Waffle, compare PR https://github.com/infolab-csail/whoami/pull/160.

- For Quantified Code, it also appears to be shut down, since their
website says:
> Domain takeover by LinuxSec
> ogatarina@pm.me